### PR TITLE
Fix typo  at "Denoise Non-Linear Means.js" file

### DIFF
--- a/Scripts/Flow/Video/Video - Denoise Non-Linear Means.js
+++ b/Scripts/Flow/Video/Video - Denoise Non-Linear Means.js
@@ -1,7 +1,7 @@
 /**
  * Denoise frames using Non-Local Means algorithm.
  * @author Alexander von Schmidsfeld
- * @revision 1
+ * @revision 2
  * @minimumVersion 1.0.0.0
  * @param {string} Strength Set denoising strength. Default is 1.0. Must be in range [1.0, 30.0].
  * @param {int} Patch Set patch size. Default is 5. Must be odd number in range [0, 99].
@@ -9,7 +9,7 @@
  * @output Deblocked Video 
  */
 
-function Script(strenght,patch,research)
+function Script(strength,patch,research)
 {
   let ffmpeg = Variables.FfmpegBuilderModel;
   if(!ffmpeg)


### PR DESCRIPTION
"strength" was typed as "strenght" in the function parameters. This caused an error always because no strength could be provided to the video filter.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
