### PR TITLE
Added scripts to run AbAv1 + install the prerequisites

### DIFF
--- a/Scripts/Flow/Video/Video - Devedse - InstallAbAv1.js
+++ b/Scripts/Flow/Video/Video - Devedse - InstallAbAv1.js
@@ -1,0 +1,143 @@
+/**
+ * Important: This script was made to be ran with the docker version of FileFlows. Results on other platforms may vary.
+ * Checks for the latest release of ab-av1, compares with the stored version,
+ * and updates if the latest version is newer.
+ * @author Devedse
+ * @revision 4
+ * @minimumVersion 1.0.0.0
+ * @output The command succeeded
+ */
+function Script()
+{
+    let targetDirectory = '/app/Data/tools/ab-av1/';
+    let versionFilePath = targetDirectory + 'version.txt';
+
+    // Fetch the latest release information
+    let releaseInfo = Flow.Execute({
+        command: 'curl',
+        argumentList: ['-s', 'https://api.github.com/repos/alexheretic/ab-av1/releases/latest']
+    });
+    if(releaseInfo.exitCode !== 0){
+        Logger.ELog('Failed to fetch release information.');
+        return -1;
+    }
+
+    // Parse the JSON for the latest version
+    let latestVersion;
+    try {
+        let releaseData = JSON.parse(releaseInfo.output);
+        latestVersion = releaseData.tag_name;
+    } catch (error) {
+        Logger.ELog('Error parsing JSON: ' + error);
+        return -1;
+    }
+
+    Logger.ILog('Latest version online: ' + latestVersion);
+
+    // Read the existing version if the file exists
+    let readVersion = Flow.Execute({
+        command: 'cat',
+        argumentList: [versionFilePath]
+    });
+
+    if (readVersion.exitCode === 0 && readVersion.output.trim() === latestVersion) {
+        Logger.ILog('ab-av1 is up-to-date.');
+        return 1;
+    }
+    
+    
+    Logger.ILog('ab-av1 is not up to date (' + readVersion.output.trim() + '), downloading new version...');
+
+    // Install zstd if not already installed
+    let installZstd = Flow.Execute({
+        command: 'apt-get',
+        argumentList: ['update']
+    });
+    if(installZstd.exitCode !== 0){
+        Logger.ELog('Failed to update package list.');
+        return -1;
+    }
+
+    installZstd = Flow.Execute({
+        command: 'apt-get',
+        argumentList: ['install', '-y', 'zstd']
+    });
+    if(installZstd.exitCode !== 0){
+        Logger.ELog('Failed to install zstd.');
+        return -1;
+    }
+
+
+    let assetUrl = '';
+    try {
+        // Parse the JSON response
+        let releaseData = JSON.parse(releaseInfo.output);
+
+        // Loop through assets to find the one ending with .tar.zst
+        for (let asset of releaseData.assets) {
+            if (asset.browser_download_url.endsWith('.tar.zst')) {
+                assetUrl = asset.browser_download_url;
+                break;
+            }
+        }
+
+        if (assetUrl) {
+            Logger.ILog('Download URL: ' + assetUrl);
+        } else {
+            Logger.ELog('No asset found ending with .tar.zst');
+            return -1;
+        }
+    } catch (error) {
+        Logger.ELog('Error parsing JSON: ' + error);
+        return -1;
+    }
+
+
+    // URL of the release and target directory
+    let targetDirectory = '/app/Data/tools/ab-av1/';
+    let archivePath = targetDirectory + 'ab-av1.tar.zst';
+
+    // Ensure target directory exists
+    let mkdir = Flow.Execute({
+        command: 'mkdir',
+        argumentList: ['-p', targetDirectory]
+    });
+    if(mkdir.exitCode !== 0){
+        Logger.ELog('Failed to create directory: ' + targetDirectory);
+        return -1;
+    }
+
+    // Download the file
+    let download = Flow.Execute({
+        command: 'curl',
+        argumentList: ['-L', '-o', archivePath, assetUrl]
+    });
+    if(download.exitCode !== 0){
+        Logger.ELog('Failed to download file: ' + assetUrl);
+        return -1;
+    }
+
+    // Extract the file
+    let extract = Flow.Execute({
+        command: 'tar',
+        argumentList: ['--use-compress-program=unzstd', '-xvf', archivePath, '-C', targetDirectory]
+    });
+    if(extract.exitCode !== 0){
+        Logger.ELog('Failed to extract file to ' + targetDirectory);
+        return -1;
+    }
+
+    // After successful extraction, write the latest version to the version file
+    let writeVersion = Flow.Execute({
+        command: 'sh',
+        argumentList: ['-c', `echo "${latestVersion}" > "${versionFilePath}"`]
+    });
+
+    if(writeVersion.exitCode !== 0){
+        Logger.ELog('Failed to write new version to file.');
+        return -1;
+    }
+
+    Logger.ILog('File extracted successfully to ' + targetDirectory);
+    return 1;
+}

--- a/Scripts/Flow/Video/Video - Devedse - InstallFfmpegBtbN.js
+++ b/Scripts/Flow/Video/Video - Devedse - InstallFfmpegBtbN.js
@@ -1,0 +1,140 @@
+/**
+ * Important: This script was made to be ran with the docker version of FileFlows. Results on other platforms may vary.
+ * Checks for the latest release of FFmpeg, compares with the stored version,
+ * and updates if the latest version is newer.
+ * @author Devedse
+ * @revision 4
+ * @minimumVersion 1.0.0.0
+ * @output The command succeeded
+ */
+function Script()
+{
+    let targetDirectory = '/app/Data/tools/ffmpegbtbn/';
+    let versionFilePath = targetDirectory + 'version.txt';
+
+    // Fetch the latest release information
+    let releaseInfo = Flow.Execute({
+        command: 'curl',
+        argumentList: ['-s', 'https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest']
+    });
+    if(releaseInfo.exitCode !== 0){
+        Logger.ELog('Failed to fetch release information.');
+        return -1;
+    }
+
+    // Parse the JSON for the latest version
+    let latestVersion;
+    try {
+        let releaseData = JSON.parse(releaseInfo.output);
+        latestVersion = releaseData.name;
+    } catch (error) {
+        Logger.ELog('Error parsing JSON: ' + error);
+        return -1;
+    }
+
+    Logger.ILog('Latest FFmpeg version online: ' + latestVersion);
+
+    // Read the existing version if the file exists
+    let readVersion = Flow.Execute({
+        command: 'cat',
+        argumentList: [versionFilePath]
+    });
+
+    if (readVersion.exitCode === 0 && readVersion.output.trim() === latestVersion) {
+        Logger.ILog('FFmpeg is up-to-date.');
+
+        Variables.FfmpegBtbn = targetDirectory;
+        Logger.ILog('Set Variables.FfmpegBtbn to ' + targetDirectory);
+        
+        return 1;
+    }
+    
+    Logger.ILog('FFmpeg is not up to date (' + readVersion.output.trim() + '), downloading new version...');
+
+    let assetUrl = '';
+    try {
+        let releaseData = JSON.parse(releaseInfo.output);
+
+        // Loop through assets to find the one ending with .tar.xz
+        for (let asset of releaseData.assets) {
+            if (asset.browser_download_url.endsWith('linux64-gpl.tar.xz')) {
+                assetUrl = asset.browser_download_url;
+                break;
+            }
+        }
+
+        if (assetUrl) {
+            Logger.ILog('Download URL: ' + assetUrl);
+        } else {
+            Logger.ELog('No asset found ending with linux64-gpl.tar.xz');
+            return -1;
+        }
+    } catch (error) {
+        Logger.ELog('Error parsing JSON: ' + error);
+        return -1;
+    }
+
+    // URL of the release and target directory
+    let archivePath = targetDirectory + 'ffmpeg.tar.xz';
+
+    // Ensure target directory exists
+    let mkdir = Flow.Execute({
+        command: 'mkdir',
+        argumentList: ['-p', targetDirectory]
+    });
+    if(mkdir.exitCode !== 0){
+        Logger.ELog('Failed to create directory: ' + targetDirectory);
+        return -1;
+    }
+
+    // Download the file
+    let download = Flow.Execute({
+        command: 'curl',
+        argumentList: ['-L', '-o', archivePath, assetUrl]
+    });
+    if(download.exitCode !== 0){
+        Logger.ELog('Failed to download file: ' + assetUrl);
+        return -1;
+    }
+
+    // Extract the contents of the bin directory directly into the target directory
+    let extract = Flow.Execute({
+        command: 'tar',
+        argumentList: ['-xvf', archivePath, '-C', targetDirectory, '--strip-components=2', 'ffmpeg-master-latest-linux64-gpl/bin/']
+    });
+    if(extract.exitCode !== 0){
+        Logger.ELog('Failed to extract contents of bin directory to ' + targetDirectory);
+        return -1;
+    }
+
+    // Make all files without an extension in the target directory executable
+    let makeExecutable = Flow.Execute({
+        command: 'find',
+        argumentList: [targetDirectory, '-type', 'f', '!', '-name', '*.*', '-exec', 'chmod', '+x', '{}', ';']
+    });
+    if(makeExecutable.exitCode !== 0){
+        Logger.ELog('Failed to make files executable in ' + targetDirectory);
+        return -1;
+    }
+
+    Logger.ILog('Made all files without an extension in ' + targetDirectory + ' executable');
+
+    // After successful extraction, write the latest version to the version file
+    let writeVersion = Flow.Execute({
+        command: 'sh',
+        argumentList: ['-c', `echo "${latestVersion}" > "${versionFilePath}"`]
+    });
+
+    if(writeVersion.exitCode !== 0){
+        Logger.ELog('Failed to write new version to file.');
+        return -1;
+    }
+
+    Logger.ILog('FFmpeg extracted successfully to ' + targetDirectory);
+
+    // Set the variable with the directory path
+    Variables.FfmpegBtbn = targetDirectory;
+    Logger.ILog('Set Variables.FfmpegBtbn to ' + targetDirectory);
+
+    return 1;
+}

--- a/Scripts/Flow/Video/Video - Devedse - RunAbAv1.js
+++ b/Scripts/Flow/Video/Video - Devedse - RunAbAv1.js
@@ -1,0 +1,83 @@
+/**
+ * Important: This script was made to be ran with the docker version of FileFlows. Results on other platforms may vary.
+ * Prerequisites:
+ *  Video - Devedse - InstallFfmpegBtbN.js
+ *  Video - Devedse - InstallAbAv1.js
+ * Executes the ab-av1 command.
+ * @author Devedse
+ * @revision 2
+ * @minimumVersion 1.0.0.0
+ * @param {int} Preset The preset to use
+ * @param {string} SvtArguments The --svt arguments to pass to AbAv1
+ * @param {string} PixFormat The --pix-format argument to pass to AbAv1
+ * @param {string} MinVmaf The VMAF value to go for (e.g. 95.0)
+ * @param {bool} Thorough Keep searching until a crf is found no more than min_vmaf+0.05 or all possibilities have been attempted.
+ * @output The command succeeded
+ * @output Variables.AbAv1CRFValue: The detected CRF value
+ */
+function Script(Preset,SvtArguments,PixFormat,MinVmaf,Thorough)
+{
+
+    let targetDirectory = '/app/Data/tools/ab-av1/';
+
+    let ffmpegBtbnDirectory = Variables.FfmpegBtbn;
+    if(!ffmpegBtbnDirectory){
+        Logger.ELog('Variables.FfmpegBtbn was not set. Ensure the InstallFfmpegBtbN script was run before this script.');
+        return -1;
+    }
+    Logger.ILog('FfmpegBtbn directory: ' + ffmpegBtbnDirectory);
+
+    // Get the input file path from Flow.WorkingFile
+    var fi = FileInfo(Flow.WorkingFile);
+
+    // Check if ab-av1 exists
+    let abAv1Path = targetDirectory + 'ab-av1';
+    let checkAbAv1 = Flow.Execute({
+        command: 'ls',
+        argumentList: [abAv1Path]
+    });
+    if(checkAbAv1.exitCode !== 0){
+        Logger.ELog('ab-av1 not found at ' + abAv1Path);
+        return -1;
+    }
+
+    let abav1Command = `${abAv1Path} crf-search --svt ${SvtArguments} --pix-format ${PixFormat} -i '${fi.FullName}' --min-vmaf ${MinVmaf} --preset ${Preset}`
+    if (Thorough == true) {
+        abav1Command += ' --thorough'
+    }
+
+    let executeAbAv1 = Flow.Execute({
+    command: 'sh',
+    argumentList: [
+            '-c',
+            `PATH=${Variables.FfmpegBtbn}:$PATH ` + 
+            abav1Command
+        ]
+    });
+
+    if(executeAbAv1.exitCode !== 0){
+        Logger.ELog('Failed to execute ab-av1: ' + executeAbAv1.exitCode);
+        return -1;
+    }
+
+    Logger.ILog('ab-av1 executed successfully.');
+
+
+    // Parse the output to find the CRF value
+    let output = executeAbAv1.output;
+    let crfValueMatch = output.match(/crf (\d+) VMAF.*predicted video stream size/);
+    if (crfValueMatch && crfValueMatch.length > 1) {
+        let crfValue = crfValueMatch[1];
+        Logger.ILog('Detected CRF value vased on VMAF: ' + crfValue);
+
+        Logger.ILog('Set Variables.AbAv1CRFValue to ' + crfValue);
+        // Set the CRF value for use in another node
+        Variables.AbAv1CRFValue = crfValue;
+        return 1;
+    } else {
+        Logger.ELog('CRF value not found in output');
+        return 0;
+    }
+
+    return 1;
+}


### PR DESCRIPTION
I've added 3 scripts which all need to be ran in sequence to be able to install everything required for Ab-Av1.
Ab-Av1 is a tool that can determine what -crf value to use based on a desired VMAF value.

This won't need any dependencies as it obtains everything from the internet.

Some things to think about before mergin:
* I'm placing file in /app/Data/tools. This directory is hard coded as there is no variable available where FileFlows stores it's data. I would suggest exposing this to the scripts so I can create a tools folder under there and things will work. Without this I'm pretty sure other platforms won't work besides docker.
* All file downloading / reading / writing is done using bash commands. Currently this is the only way, but I think it would be better to expose functionality to be able to do File.Download and WebRequest.Get. This is however currently not supported.
* The FFMPEG version I'm downloading seems to have been compiled with more options then the one used by FileFlows by default. It might be interesting to investigate switch over? But I'll leave this up to you to decide. (VMAF is something that's really interesting to determine what CRF to use and this is not supported by the EMBY version of FFMPEG)

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
