### PR TITLE
Detects the dynamic range type

### DIFF
--- a/Scripts/Flow/Video/Video - Dynamic range.js
+++ b/Scripts/Flow/Video/Video - Dynamic range.js
@@ -1,0 +1,36 @@
+/**
+ * Detects the dynamic range of a video e.g. SDR/HDR/HDR+DoVi/Dovi
+ * @author Lawrence Curtis
+ * @version 1.0.0
+ * @revision 1
+ * @output SDR
+ * @output HDR
+ * @output HDR + Dolby Vision
+ * @output Dolby Vison only
+ */
+function Script() {
+    const videoStreams = Variables.vi.VideoInfo.VideoStreams;
+
+    if (videoStreams) {
+        if (videoStreams.length > 0) {
+            Logger.DLog("Checking video dyanmic range...");
+            if (videoStreams[0].HDR) {
+                if (videoStreams[0].DolbyVision) {
+                    Logger.ILog("Video range is both HDR + Dolby Vision");
+                    return 3;
+                }
+                Logger.ILog("Video range is HDR");
+                return 2;
+            }
+            if (videoStreams[0].DolbyVision) {
+                Logger.ILog("Video range is Dolby Vision");
+                return 4;
+            }
+        }
+        Logger.ILog("Video range is SDR");
+        return 1;
+    } else {
+        Logger.WLog("No dynamic range found");
+        return -1;
+    }
+}


### PR DESCRIPTION
Detects the dynamic range of a video e.g. SDR/HDR/HDR+DoVi/Dovi

Unsure how useful this is but I use it a lot in combination with my blocklist script as I never want Dolby Vision only videos

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
