### PR TITLE
Fix typo in Sonarr getShowFileByPath

### DIFF
--- a/Scripts/Shared/Sonarr.js
+++ b/Scripts/Shared/Sonarr.js
@@ -150,7 +150,7 @@ export class Sonarr
             let sp = x.path.toLowerCase();
             if (!sp)
                 return false;
-            return sp.includes(path);
+            return sp.includes(cp);
         });
         if (showfile?.length)
         {


### PR DESCRIPTION
Fixes a typo where the lower-case Sonarr path was compared with the mixed-case Original File Path instead of its lower-case version.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
