### PR TITLE
Update Video - Devedse - RunAbAv1.js; fix regex to pickup final CRF value

### DIFF
--- a/Scripts/Flow/Video/Video - Devedse - RunAbAv1.js
+++ b/Scripts/Flow/Video/Video - Devedse - RunAbAv1.js
@@ -5,7 +5,7 @@
  *  Video - Devedse - InstallAbAv1.js
  * Executes the ab-av1 command.
  * @author Devedse
- * @revision 6
+ * @revision 7
  * @uid 4b2d95ff-0b20-4be2-b945-e6efd8099feb
  * @param {string} Preset The preset to use
  * @param {string} SvtArguments The --svt arguments to pass to AbAv1. Only use if using SVT-AV1 encoder

--- a/Scripts/Flow/Video/Video - Devedse - RunAbAv1.js
+++ b/Scripts/Flow/Video/Video - Devedse - RunAbAv1.js
@@ -93,7 +93,7 @@ function Script(Preset,SvtArguments,Encoder,PixFormat,MinVmaf,MaxEncodedPercent,
 
     // Parse the output to find the CRF value
     let output = executeAbAv1.output;
-    let crfValueMatch = output.match(/crf (\d+\.?\d*) VMAF.*predicted video stream size/);
+    let crfValueMatch = output.match(/ab_av1::command::crf_search\] crf (\d+\d) successful/);
     Logger.ILog('crf: ' + crfValueMatch);
     if (crfValueMatch && crfValueMatch.length > 1) {
         let crfValue = crfValueMatch[1];


### PR DESCRIPTION
Existing logic for detecting final VMAF value is incorrect - it is picking up the first VMAF calculated, not the final value.   Most likely due to changes in the logging output of ab-av1.   This change picks up the final calculated VMAF using a more precise match pattern.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
