### PR TITLE
[Dovi fix] Change detection logic

### DIFF
--- a/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
+++ b/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
@@ -61,6 +61,9 @@ function Script(RemoveHDRTenPlus) {
 
   executeArgs.command = ffmpeg;
   executeArgs.argumentList = [
+    "-v",
+    "quiet",
+    "-stats",
     "-i",
     original,
     "-c:v",
@@ -140,10 +143,17 @@ function Script(RemoveHDRTenPlus) {
 
   executeArgs.command = ffmpeg;
   executeArgs.argumentList = [
+    "-v",
+    "quiet",
+    "-stats",
     "-i",
     working,
     "-c:v",
     "copy",
+    "-bsf:v",
+    "hevc_mp4toannexb",
+    "-f",
+    "hevc",
     Flow.TempPath + "/converted_video.hevc",
   ];
 

--- a/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
+++ b/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
@@ -5,7 +5,7 @@ Run between encode and move/replace.
 Output is always an MKV.
 dovi_tool only supports HEVC when AV1 support is added I will updated this script.
  * @author Lawrence Curtis
- * @revision 1
+ * @revision 2
  * @uid f5eebc75-e22d-4181-af02-5e7263e68acd
  * @param {bool} RemoveHDRTenPlus Remove HDR10+, this fixes the black screen issues on FireStick
  * @output Fixed


### PR DESCRIPTION
This changes the detection logic by looking at the original video rather than using the Variables which will be from the generated video. 

Using jellyfin builds this is not a problem but as BTN can't copy over the DoVi RPU itself I needed to change the logic.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
