### PR TITLE
New Script: Folder - Copy or Move Contents.js

### DIFF
--- a/Scripts/Flow/Folder/Folder - Copy or Move Contents.js
+++ b/Scripts/Flow/Folder/Folder - Copy or Move Contents.js
@@ -1,6 +1,6 @@
 /**
  * @name Folder - Copy or Move Contents
- * @uid E35D65B5-1486-42B9-8A0C-651804ADEA88
+ * @uid e35d65b5-1486-42b9-8a0c-651804adea88
  * @description Copies or Movies a subset of files from a folder based on supplied filename
  * @author apwelsh
  * @revision 1.0

--- a/Scripts/Flow/Folder/Folder - Copy or Move Contents.js
+++ b/Scripts/Flow/Folder/Folder - Copy or Move Contents.js
@@ -1,5 +1,6 @@
 /**
  * @name Folder - Copy or Move Contents
+ * @uid E35D65B5-1486-42B9-8A0C-651804ADEA88
  * @description Copies or Movies a subset of files from a folder based on supplied filename
  * @author apwelsh
  * @revision 1.0

--- a/Scripts/Flow/Folder/Folder - Copy or Move Contents.js
+++ b/Scripts/Flow/Folder/Folder - Copy or Move Contents.js
@@ -1,0 +1,62 @@
+/**
+ * @name Folder - Copy or Move Contents
+ * @description Copies or Movies a subset of files from a folder based on supplied filename
+ * @author apwelsh
+ * @revision 1.0
+ * @param {string} SourceDirectory The directory to copy (typically the folder being processed ex: {folder.FullName})
+ * @param {string} DestinationDirectory The directory location to copy to (typically the location your servarr app is looking to for completed downloads)
+ * @param {string} MediaFileName The file basename to copy all matching files of. The paths, and extension coponents will be ignored.  (typically {file.Name})
+ * @param {bool} MoveFiles Set true to move, or false to copy
+ * @output Directory copied
+ */
+function Script(SourceDirectory, DestinationDirectory, MediaFileName, MoveFiles)
+ {
+     MoveFiles = MoveFiles || false;
+     let src = Flow.ReplaceVariables(SourceDirectory);
+     let dest = System.IO.Path.Combine(Flow.ReplaceVariables(DestinationDirectory), System.IO.Path.GetFileName(src));
+
+
+     // Create filter of provided file basename, w/o extension, or * if none provided
+     let filter = System.IO.Path.GetFileNameWithoutExtension(Flow.ReplaceVariables(MediaFileName || "*")) + ".*";
+
+     if(System.IO.Directory.Exists(dest) == false)
+        System.IO.Directory.CreateDirectory(dest);
+
+     // recursively locate all the full paths of files matching the input criteria.
+     let allFiles = System.IO.Directory.GetFiles(src, filter, System.IO.SearchOption.AllDirectories);
+     for (let srcFile of allFiles) 
+     {
+         // This method will flatten a complex directory structure into files under a single folder.
+         let dstFile = System.IO.Path.Combine(dest, System.IO.Path.GetFileName(srcFile));
+
+         if (MoveFiles) {
+             System.IO.File.Move(srcFile, dstFile, true);
+         } else {
+             System.IO.File.Copy(srcFile, dstFile, true);
+         }
+     }
+
+     if (MoveFiles) {
+         cleanDirectory(src);
+     }
+ 
+     return 1;
+ }
+
+function cleanDirectory(directory)
+{
+    let allFolder = System.IO.Directory.GetDirectories(directory, "*", System.IO.SearchOption.AllDirectories);
+    allFolder.sort((a,b) => b.length - a.length);
+
+    for (subdir in System.IO.Directory.GetDirectories(directory))
+    {
+        if (System.IO.Directory.GetFiles(subdir).Length == 0 && System.IO.Directory.GetDirectories(subdir).Length == 0)
+        {
+            Directory.Delete(direcsubdirtory, false);
+        }
+    }
+    if (System.IO.Directory.GetFiles(directory).Length == 0 && System.IO.Directory.GetDirectories(directory).Length == 0)
+    {
+        Directory.Delete(directory, false);
+    }
+}


### PR DESCRIPTION
Add new script for an improved copy/move folder script that is compatible with moving contents of folders when a folder contains more more than 1 work-unit to be processed by flows separately.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
