### PR TITLE
Fix Radarr - Get Original Language.js -- missing URL and API key

### DIFF
--- a/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
@@ -14,7 +14,7 @@ import { Radarr } from '../../../Shared/Radarr';
  */
 function Script(URI, ApiKey, Path, ISO2)
 {
-    URI = URI || Variables["Radarr.URI"];
+    URI = URI || Variables["Radarr.Url"] || Variables["Radarr.URI"];
     ApiKey = ApiKey || Variables["Radarr.ApiKey"];
     
     if(!Path)

--- a/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
@@ -14,6 +14,9 @@ import { Radarr } from '../../../Shared/Radarr';
  */
 function Script(URI, ApiKey, Path, ISO2)
 {
+    URI = URI || Variables["Radarr.URI"];
+    ApiKey = ApiKey || Variables["Radarr.ApiKey"];
+    
     if(!Path)
         return 2;
     const radarr = new Radarr(URI, ApiKey);

--- a/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
@@ -4,15 +4,15 @@ import { Radarr } from '../../../Shared/Radarr';
  * @author reven 
  * @uid 3915f110-4b07-4e11-b7b9-50de3f5a1255
  * @description Lookups a file in Radarr and gets its original language ISO-693-1 code for it
- * @revision 6
- * @param {string} URL Radarr root URL and port (e.g., http://radarr:1234)
- * @param {string} ApiKey API Key for Radarr
+ * @revision 7
  * @param {string} Path The full file path to lookup in Radarr
  * @param {bool} ISO2 If ISO-639-2 should be returned, otherwise ISO-639-1 will be used
+ * @param {string} URL Radarr root URL and port (e.g., http://radarr:1234)
+ * @param {string} ApiKey API Key for Radarr
  * @output The language was found and stored in the variable OriginalLanguage
  * @output The language was not found
  */
-function Script(URI, ApiKey, Path, ISO2)
+function Script(Path, ISO2, URI, ApiKey)
 {
     URI = URI || Variables["Radarr.Url"] || Variables["Radarr.URI"];
     ApiKey = ApiKey || Variables["Radarr.ApiKey"];

--- a/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
@@ -5,14 +5,14 @@ import { Radarr } from '../../../Shared/Radarr';
  * @uid 3915f110-4b07-4e11-b7b9-50de3f5a1255
  * @description Lookups a file in Radarr and gets its original language ISO-693-1 code for it
  * @revision 6
- * @param {string} Path The full file path to lookup in Radarr
- * @param {bool} ISO2 If ISO-639-2 should be returned, otherwise ISO-639-1 will be used
  * @param {string} URL Radarr root URL and port (e.g., http://radarr:1234)
  * @param {string} ApiKey API Key for Radarr
+ * @param {string} Path The full file path to lookup in Radarr
+ * @param {bool} ISO2 If ISO-639-2 should be returned, otherwise ISO-639-1 will be used
  * @output The language was found and stored in the variable OriginalLanguage
  * @output The language was not found
  */
-function Script(Path, ISO2, URI, ApiKey)
+function Script(URI, ApiKey, Path, ISO2)
 {
     if(!Path)
         return 2;

--- a/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Get Original Language.js
@@ -7,14 +7,16 @@ import { Radarr } from '../../../Shared/Radarr';
  * @revision 6
  * @param {string} Path The full file path to lookup in Radarr
  * @param {bool} ISO2 If ISO-639-2 should be returned, otherwise ISO-639-1 will be used
+ * @param {string} URL Radarr root URL and port (e.g., http://radarr:1234)
+ * @param {string} ApiKey API Key for Radarr
  * @output The language was found and stored in the variable OriginalLanguage
  * @output The language was not found
  */
-function Script(Path, ISO2)
+function Script(Path, ISO2, URI, ApiKey)
 {
     if(!Path)
         return 2;
-    const radarr = new Radarr();
+    const radarr = new Radarr(URI, ApiKey);
     try
     {
         let language = radarr.getOriginalLanguageFromPath(Path.toString());

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Get Original Language.js
@@ -6,16 +6,21 @@ import { Sonarr } from '../../../Shared/Sonarr';
  * @uid 51cf3c4f-f4a3-45e2-a083-6629397aab90
  * @revision 8
  * @description Lookups a file in Sonarr and gets its original language ISO-693-1 code for it
+ * @param {string} URL Sonarr root URL and port (e.g., http://sonarr:1234)
+ * @param {string} ApiKey API Key for Sonarr
  * @param {string} Path The full file path to lookup in Sonarr
  * @param {bool} ISO2 If ISO-639-2 should be returned, otherwise ISO-639-1 will be used
  * @output The language was found and stored in the variable OriginalLanguage
  * @output The language was not found
  */
-function Script(Path, ISO2)
+function Script(URI, ApiKey, Path, ISO2)
 {
+    URI = URI || Variables["Sonarr.URI"];
+    ApiKey = ApiKey || Variables["Sonarr.ApiKey"];
+    
     if(!Path)
         return 2;
-    const sonarr = new Sonarr();
+    const sonarr = new Sonarr(URI, ApiKey);
     try
     {
         let language = sonarr.getOriginalLanguageFromPath(Path.toString());

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Get Original Language.js
@@ -15,7 +15,7 @@ import { Sonarr } from '../../../Shared/Sonarr';
  */
 function Script(URI, ApiKey, Path, ISO2)
 {
-    URI = URI || Variables["Sonarr.URI"];
+    URI = URI || Variables["Sonarr.Url"] || Variables["Sonarr.URI"];
     ApiKey = ApiKey || Variables["Sonarr.ApiKey"];
     
     if(!Path)

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Get Original Language.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Get Original Language.js
@@ -4,16 +4,16 @@ import { Sonarr } from '../../../Shared/Sonarr';
 /**
  * @author reven 
  * @uid 51cf3c4f-f4a3-45e2-a083-6629397aab90
- * @revision 8
+ * @revision 9
  * @description Lookups a file in Sonarr and gets its original language ISO-693-1 code for it
- * @param {string} URL Sonarr root URL and port (e.g., http://sonarr:1234)
- * @param {string} ApiKey API Key for Sonarr
  * @param {string} Path The full file path to lookup in Sonarr
  * @param {bool} ISO2 If ISO-639-2 should be returned, otherwise ISO-639-1 will be used
+ * @param {string} URL Sonarr root URL and port (e.g., http://sonarr:1234)
+ * @param {string} ApiKey API Key for Sonarr
  * @output The language was found and stored in the variable OriginalLanguage
  * @output The language was not found
  */
-function Script(URI, ApiKey, Path, ISO2)
+function Script(Path, ISO2, URI, ApiKey)
 {
     URI = URI || Variables["Sonarr.Url"] || Variables["Sonarr.URI"];
     ApiKey = ApiKey || Variables["Sonarr.ApiKey"];


### PR DESCRIPTION
## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.

The current script lacks an URL and an API key, so there is no way it can get anything out of Radarr