### PR TITLE
Added qbittorent scripts

### DIFF
--- a/Scripts/Flow/Applications/qBittorrent/qBittorrent - Renamer.js
+++ b/Scripts/Flow/Applications/qBittorrent/qBittorrent - Renamer.js
@@ -10,9 +10,11 @@
  * @output Item not found or not renamed
  */
 function Script(URI) {
+  URI = URI || Variables["QBittorrent.URI"];
+
   const qbittorrent = new QBittorrent(URI);
   return qbittorrent.check(
-    Variables.folder.Orig.Name,
+    Flow.UnMapPath(Variables.folder.Orig.Name),
     Variables.file.Orig.Name,
     Variables.file.Name
   );

--- a/Scripts/Flow/Applications/qBittorrent/qBittorrent - Renamer.js
+++ b/Scripts/Flow/Applications/qBittorrent/qBittorrent - Renamer.js
@@ -1,0 +1,99 @@
+/**
+ * @name qBittorrent - Renamer
+ * @description Renames the current file in qBittorrent, Run after move / delete original.
+ * This requires you don't have authentication on qBittorrent or different path mappings
+ * @author lawrence
+ * @uid 4130f59f-3871-4c24-9a0d-15966da6eb7c
+ * @revision 1
+ * @param {string} URI qBittorent root URI and port (e.g. http://qbitorrent:8080)
+ * @output Item Renamed
+ * @output Item not found or not renamed
+ */
+function Script(URI) {
+  const qbittorrent = new QBittorrent(URI);
+  return qbittorrent.check(
+    Variables.folder.Orig.Name,
+    Variables.file.Orig.Name,
+    Variables.file.Name
+  );
+}
+
+class QBittorrent {
+  constructor(uri) {
+    if (!URI) {
+      Flow.Fail("qBittorrent: No URI specified");
+    }
+
+    this.uri = uri;
+  }
+
+  getUrl(endpoint) {
+    let url = "" + this.uri;
+    if (url.endsWith("/") === false) url += "/";
+    return `${url}api/v2/${endpoint}`;
+  }
+
+  getJson(endpoint) {
+    let url = this.getUrl(endpoint);
+    let response = http.GetAsync(url).Result;
+
+    let body = response.Content.ReadAsStringAsync().Result;
+    if (!response.IsSuccessStatusCode) {
+      Flow.Fail("Unable to fetch: " + endpoint + "\n" + body);
+    }
+    return JSON.parse(body);
+  }
+
+  postJson(endpoint, data) {
+    let url = this.getUrl(endpoint);
+    let response = http.PostAsync(url, data).Result;
+
+    let body = response.Content.ReadAsStringAsync().Result;
+    if (!response.IsSuccessStatusCode) {
+      Flow.Fail("Unable to rename: " + endpoint + "\n" + body);
+    }
+    return body;
+  }
+
+  check(path, oldName, newName) {
+    let queue = this.getJson("torrents/info");
+    path = path.replace(/\W/gi, "");
+    if (!queue) return 2;
+
+    let renamed = false;
+
+    queue.forEach((item) => {
+      if (item.content_path.replace(/\W/gi, "").includes(path)) {
+        Logger.ILog(`Identified item ${item.name} from ${item.content_path}`);
+
+        if (oldName != newName) {
+          let files = this.getJson(`torrents/files?hash=${item.hash}`);
+          files.forEach((file) => {
+            if (file.name.includes(oldName)) {
+              newName = file.name.replace(oldName, newName);
+
+              var Dick = System.Collections.Generic.Dictionary(
+                System.String,
+                System.String
+              );
+              var list = new Dick();
+              list.Add("hash", item.hash);
+              list.Add("oldPath", file.name);
+              list.Add("newPath", newName);
+              let data = FormUrlEncodedContent(list);
+
+              this.postJson("torrents/renameFile", data);
+              renamed = true;
+            }
+          });
+        } else {
+          Logger.DLog("Did not rename, item has the same name or is seeding");
+        }
+      }
+    });
+
+    if (renamed) return 1;
+
+    return 2;
+  }
+}

--- a/Scripts/Flow/Applications/qBittorrent/qBittorrent - Seeding check.js
+++ b/Scripts/Flow/Applications/qBittorrent/qBittorrent - Seeding check.js
@@ -10,52 +10,56 @@
  * @output Item not found or seeding
  */
 function Script(URI) {
-  const qbittorrent = new QBittorrent(URI);
-  return qbittorrent.check(Variables.folder.Orig.Name);
+    URI = URI || Variables["QBittorrent.URI"];
+
+    const qbittorrent = new QBittorrent(URI);
+    return qbittorrent.check(Flow.UnMapPath(Variables.folder.Orig.Name));
 }
 
 class QBittorrent {
-  constructor(uri) {
-    if (!URI) {
-      Flow.Fail("qBittorrent: No URI specified");
+    constructor(uri) {
+        if (!URI) {
+            Flow.Fail("qBittorrent: No URI specified");
+        }
+
+        this.uri = uri;
     }
 
-    this.uri = uri;
-  }
-
-  getUrl(endpoint) {
-    let url = "" + this.uri;
-    if (url.endsWith("/") === false) url += "/";
-    return `${url}api/v2/${endpoint}`;
-  }
-
-  getJson(endpoint) {
-    let url = this.getUrl(endpoint);
-    let response = http.GetAsync(url).Result;
-
-    let body = response.Content.ReadAsStringAsync().Result;
-    if (!response.IsSuccessStatusCode) {
-      Flow.Fail("Unable to fetch: " + endpoint + "\n" + body);
+    getUrl(endpoint) {
+        let url = "" + this.uri;
+        if (url.endsWith("/") === false) url += "/";
+        return `${url}api/v2/${endpoint}`;
     }
-    return JSON.parse(body);
-  }
 
-  check(path) {
-    let seeding = false;
-    let queue = this.getJson("torrents/info");
-    path = path.replace(/\W/gi, "");
-    if (!queue) return 2;
+    getJson(endpoint) {
+        let url = this.getUrl(endpoint);
+        let response = http.GetAsync(url).Result;
 
-    queue.forEach((item) => {
-      if (item.content_path.replace(/\W/gi, "").includes(path)) {
-        if (item.state.includes("upload")) seeding = true;
+        let body = response.Content.ReadAsStringAsync().Result;
+        if (!response.IsSuccessStatusCode) {
+            Flow.Fail("Unable to fetch: " + endpoint + "\n" + body);
+        }
+        return JSON.parse(body);
+    }
 
-        Logger.ILog(`Identified item ${item.name} from ${item.content_path}`);
-      }
-    });
+    check(path) {
+        let seeding = false;
+        let queue = this.getJson("torrents/info");
+        path = path.replace(/\W/gi, "");
+        if (!queue) return 2;
 
-    if (seeding) return 1;
+        queue.forEach((item) => {
+            if (item.content_path.replace(/\W/gi, "").includes(path)) {
+                if (item.state.includes("upload")) seeding = true;
 
-    return 2;
-  }
+                Logger.ILog(
+                    `Identified item ${item.name} from ${item.content_path}`
+                );
+            }
+        });
+
+        if (seeding) return 1;
+
+        return 2;
+    }
 }

--- a/Scripts/Flow/Applications/qBittorrent/qBittorrent - Seeding check.js
+++ b/Scripts/Flow/Applications/qBittorrent/qBittorrent - Seeding check.js
@@ -1,0 +1,61 @@
+/**
+ * @name qBittorrent - Seeding check
+ * @description Checks if the current file is seeding in qBittorrent so you can 'reprocess' later
+ * This requires you don't have authentication on qBittorrent or different path mappings
+ * @author lawrence
+ * @uid 48c1518d-83fc-416d-972d-8caf7defe424
+ * @revision 1
+ * @param {string} URI qBittorent root URI and port (e.g. http://qbitorrent:8080)
+ * @output Item is seeding
+ * @output Item not found or seeding
+ */
+function Script(URI) {
+  const qbittorrent = new QBittorrent(URI);
+  return qbittorrent.check(Variables.folder.Orig.Name);
+}
+
+class QBittorrent {
+  constructor(uri) {
+    if (!URI) {
+      Flow.Fail("qBittorrent: No URI specified");
+    }
+
+    this.uri = uri;
+  }
+
+  getUrl(endpoint) {
+    let url = "" + this.uri;
+    if (url.endsWith("/") === false) url += "/";
+    return `${url}api/v2/${endpoint}`;
+  }
+
+  getJson(endpoint) {
+    let url = this.getUrl(endpoint);
+    let response = http.GetAsync(url).Result;
+
+    let body = response.Content.ReadAsStringAsync().Result;
+    if (!response.IsSuccessStatusCode) {
+      Flow.Fail("Unable to fetch: " + endpoint + "\n" + body);
+    }
+    return JSON.parse(body);
+  }
+
+  check(path) {
+    let seeding = false;
+    let queue = this.getJson("torrents/info");
+    path = path.replace(/\W/gi, "");
+    if (!queue) return 2;
+
+    queue.forEach((item) => {
+      if (item.content_path.replace(/\W/gi, "").includes(path)) {
+        if (item.state.includes("upload")) seeding = true;
+
+        Logger.ILog(`Identified item ${item.name} from ${item.content_path}`);
+      }
+    });
+
+    if (seeding) return 1;
+
+    return 2;
+  }
+}


### PR DESCRIPTION
This introduces two scripts...

Renamer - this will change the file name inside qbt, designed to be run after the move so that if the file extension changes radarr/sonarr can still import the file, this rarely is an issue for *darr but seems to be an issue with single file torrents more than anything

Seeding check - this will check inside qbt to see if the file is seeding, so you can retry the file later

Both of these scripts have been in use for a couple of weeks now and have had no issues. 

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
