### PR TITLE
Add timeout param for shared Sonarr/Radarr scripts

### DIFF
--- a/Scripts/Shared/Radarr.js
+++ b/Scripts/Shared/Radarr.js
@@ -222,12 +222,13 @@ export class Radarr
     /**
      * Sleeps, waiting for a command to complete
      * @param {int} commandId ID of command being run
+     * @param {int} timeOut time for waiting for cammand to complete before timeour, in milliseconds (30000 milliseconds is 30 seconds).
      * @returns bool whether the coommand ran successfully
      */
-    waitForCompletion(commandId) 
+    waitForCompletion(commandId, timeOut=30000) 
     {
         const startTime = new Date().getTime();
-        const timeout = 30000; // 30 seconds in milliseconds
+        const timeout = timeOut
         const endpoint = `command/${commandId}`;
     
         while (new Date().getTime() - startTime <= timeout) {

--- a/Scripts/Shared/Radarr.js
+++ b/Scripts/Shared/Radarr.js
@@ -1,7 +1,7 @@
 /**
  * @name Radarr
  * @uid 88e66e7d-f835-4620-9616-9beaa4ee42dc
- * @revision 7
+ * @revision 8
  * @description Class that interacts with Radarr
  * @minimumVersion 1.0.0.0
  */

--- a/Scripts/Shared/Sonarr.js
+++ b/Scripts/Shared/Sonarr.js
@@ -263,12 +263,13 @@ export class Sonarr
     /**
      * Sleeps, waiting for a command to complete
      * @param {int} commandId ID of command being run
+     * @param {int} timeOut time for waiting for cammand to complete before timeour, in milliseconds (30000 milliseconds is 30 seconds).
      * @returns bool whether the coommand ran successfully
      */
-    waitForCompletion(commandId) 
+    waitForCompletion(commandId, timeOut=30000) 
     {
         const startTime = new Date().getTime();
-        const timeout = 30000;
+        const timeout = timeOut;
         const endpoint = `command/${commandId}`;
 
         while (new Date().getTime() - startTime <= timeout) {

--- a/Scripts/Shared/Sonarr.js
+++ b/Scripts/Shared/Sonarr.js
@@ -2,7 +2,7 @@
  * @name Sonarr
  * @uid 0f5836c0-d20b-4740-9824-f81b5200ec3d
  * @description Class that interacts with Sonarr
- * @revision 9
+ * @revision 10
  * @minimumVersion 1.0.0.0
  */
 export class Sonarr


### PR DESCRIPTION
Add timeout param for shared Sonarr/Radarr scripts in `waitForCompletion` method

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
