### PR TITLE
Update Video - Has 5.1 Audio.js Added Tolerance

### DIFF
--- a/Scripts/Flow/Video/Video - Has 5.1 Audio.js
+++ b/Scripts/Flow/Video/Video - Has 5.1 Audio.js
@@ -2,24 +2,26 @@
  * @author reven
  * @uid c87f9e27-6587-490b-a51e-f65e7542b891
  * @description Determines if a video has a 5.1 channel track
- * @revision 6
+ * @revision 7
  * @output Does have 5.1
  * @output Does not have 5.1
  */
 function Script() 
 {
   let audioStreams = Variables.vi?.VideoInfo?.AudioStreams;
+  const TARGET_CHANNELS = 5.1;
+  const TOLERANCE = 0.03;
+  
   if (!audioStreams) {
     Logger.ILog("no audio streams");
     return 2;
   }
-
   for (let i = 0; i < audioStreams.length; i++) {
     let audio = audioStreams[i];
     if(audio.Deleted)
       continue;
     Logger.ILog("Audio channel found: " + audio.Channels);
-    if (audio.Channels === 5.1)
+    if (Math.abs(audio.Channels - TARGET_CHANNELS) <= TOLERANCE)
       return 1;
   }
 


### PR DESCRIPTION
Added a tolerance window so that the check will still resolve true when channel counts report as long decimals due to JavaScript floating point issues.  

E.G. "Audio channel found: 5.09999990463256" =/= 5.1  //Returns Output 2
![Screenshot 2025-03-30 185931](https://github.com/user-attachments/assets/1f4aa5ac-2f64-4f36-b199-278ce432c3fd)


## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
