### PR TITLE
escape name under linux because we unwrap the arguments later

### DIFF
--- a/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
+++ b/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
@@ -106,6 +106,10 @@ function Script(RemoveHDRTenPlus) {
   Flow.PartPercentageUpdate(0);
   Flow.AdditionalInfoRecorder("DoVi", "Extracting RPU", 1);
 
+  if (Flow.IsLinux) {
+    original = `"${original}"`;
+  }
+
   // Creating RPU 8.1 file
   var executeArgs = new ExecuteArgs();
   executeArgs.command = dovi_tool;

--- a/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
+++ b/Scripts/Flow/Video/Video - Dolby Vision - Fix crop and compatibility.js
@@ -5,7 +5,7 @@ Run between encode and move/replace.
 Output is always an MKV.
 dovi_tool only supports HEVC when AV1 support is added I will updated this script.
  * @author lawrence / iBuSH
- * @revision 8
+ * @revision 9
  * @uid f5eebc75-e22d-4181-af02-5e7263e68acd
  * @param {bool} RemoveHDRTenPlus Remove HDR10+, this fixes the black screen issues on FireStick
  * @output Fixed


### PR DESCRIPTION
## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
