### PR TITLE
Misconfigured usage of sonarr.waitForCompletion in the "Sonarr - Refresh.js" script

### DIFF
--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Refresh.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Refresh.js
@@ -4,7 +4,7 @@ import { Sonarr } from 'Shared/Sonarr';
  * @description This script will refresh the file through Sonarr for processing libraries in place
  * @author Shaun Agius, Anthony Clerici : Modified by Macnemarion
  * @uid 01d7fc57-2613-4e14-92bc-29b2ba259f86
- * @revision 1
+ * @revision 2
  * @param {string} URI Sonarr root URI and port (e.g. http://sonarr:8989)
  * @param {string} ApiKey API Key
  * @output Item refreshed successfully

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Refresh.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Refresh.js
@@ -36,7 +36,7 @@ function Script(URI, ApiKey) {
         // Ensure series is refreshed
         let refreshData = sonarr.sendCommand('RefreshSeries', refreshBody);
         // Wait for the completion of the refresh
-        let refreshCompleted = sonarr.waitForCompletion(refreshData.id, sonarr);
+        let refreshCompleted = sonarr.waitForCompletion(refreshData.id);
         if (!refreshCompleted) {
             Logger.WLog('refresh failed');
             return -1;


### PR DESCRIPTION
Misconfigured usage of sonarr.waitForCompletion caused it to fail immediately with the timeout error. The sonarr class was being passed on the timeout value parameter.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
