### PR TITLE
Fix printing of return message - Run abav1

### DIFF
--- a/Scripts/Flow/Video/Video - Run ab-av1.js
+++ b/Scripts/Flow/Video/Video - Run ab-av1.js
@@ -6,7 +6,7 @@ If CRF is found, it is saved to Variables.AbAv1CRFValue.
 Executes the ab-av1 command.
  * @author CanofSocks
  * @uid e31fbd4d-dc96-4ae6-9122-a9f30c102b1d
- * @revision 4
+ * @revision 5
  * @param {string} Preset The preset to use
  * @param {string} Encoder The target encoder
  * @param {string} EncOptions A '|' separated list of additional options to pass to ab-av1. The first '=' symbol will be used to infer that this is an option with a value. Passed to ffmpeg like "x265-params=lossless=1" -> ['-x265-params', 'lossless=1'] 
@@ -78,7 +78,7 @@ function Script(Preset,Encoder,EncOptions,PixFormat,MinVmaf,MaxEncodedPercent,Mi
 
     let returnValue = search(abav1Command);
 
-    Logger.ILog(returnValue.message)
+    Logger.ILog(`${returnValue.message}`)
 
     if (returnValue.error == true){
         Logger.ELog(`${returnValue.message}`)

--- a/Scripts/Flow/Video/Video - Run ab-av1.js
+++ b/Scripts/Flow/Video/Video - Run ab-av1.js
@@ -78,7 +78,9 @@ function Script(Preset,Encoder,EncOptions,PixFormat,MinVmaf,MaxEncodedPercent,Mi
 
     let returnValue = search(abav1Command);
 
-    Logger.ILog(`${returnValue.message}`)
+    if(returnValue.message){
+        Logger.ILog(`${returnValue.message}`)
+    }
 
     if (returnValue.error == true){
         Logger.ELog(`${returnValue.message}`)


### PR DESCRIPTION
Checked if there is a message from ab-av1 before printing to ILog.

Also ensures that returnValue.message is a string via a template as the ILog appears to use a trim function that does not work for classes without a trim function

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
