### PR TITLE
Add check before trimming extracted score info

### DIFF
--- a/Scripts/Flow/Video/Video - Run ab-av1.js
+++ b/Scripts/Flow/Video/Video - Run ab-av1.js
@@ -151,9 +151,9 @@ function search(abav1Command){
             ))
         ) {
             returnValue.data.push({
-                crf: matches[2].trim(),
-                score: matches[3].trim(),
-                size: matches[4].trim(),
+                crf: matches[2] ? matches[2].trim() : null,
+                score: matches[3] ? matches[3].trim() : null,
+                size: matches[4] ? matches[4].trim() : null,
             });
         }
         if ((matches = line.match(/crf ([0-9]+) successful/i))) {

--- a/Scripts/Flow/Video/Video - Run ab-av1.js
+++ b/Scripts/Flow/Video/Video - Run ab-av1.js
@@ -6,7 +6,7 @@ If CRF is found, it is saved to Variables.AbAv1CRFValue.
 Executes the ab-av1 command.
  * @author CanofSocks
  * @uid e31fbd4d-dc96-4ae6-9122-a9f30c102b1d
- * @revision 5
+ * @revision 6
  * @param {string} Preset The preset to use
  * @param {string} Encoder The target encoder
  * @param {string} EncOptions A '|' separated list of additional options to pass to ab-av1. The first '=' symbol will be used to infer that this is an option with a value. Passed to ffmpeg like "x265-params=lossless=1" -> ['-x265-params', 'lossless=1'] 


### PR DESCRIPTION
Add check to ensure that the table fields for the ab-av1 messages have a value before attempting to trim them
## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
