### PR TITLE
Adding Manual Import along with Download Scan for better imports

### DIFF
--- a/Scripts/Flow/Applications/Radarr/Radarr - Movie Lookup.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Movie Lookup.js
@@ -3,9 +3,11 @@ import { Radarr } from 'Shared/Radarr';
 /**
  * @name Radarr - Movie Lookup
  * @description This script looks up a Movie from Radarr and retrieves its metadata
+ * @help Performs a search on Radarr for a movie.
+ * Stores the Metadata inside the variable 'MovieInfo'.
  * @author iBuSH
  * @uid 1153e3fb-e7bb-4162-87ad-5c15cd9c081f
- * @revision 6
+ * @revision 7
  * @param {string} URL Radarr root URL and port (e.g., http://radarr:1234)
  * @param {string} ApiKey API Key for Radarr
  * @param {bool} UseFolderName Whether to use the folder name instead of the file name for search
@@ -13,7 +15,7 @@ import { Radarr } from 'Shared/Radarr';
  * @output Movie not found
  */
 function Script(URL, ApiKey, UseFolderName) {
-    URL = URL || Variables['Radarr.Url'] || Variables["Radarr.URI"];
+    URL = URL || Variables['Radarr.Url'] || Variables['Radarr.URI'];
     ApiKey = ApiKey || Variables['Radarr.ApiKey'];
     const radarr = new Radarr(URL, ApiKey);
     const folderPath = Variables.folder.Orig.FullName;
@@ -23,8 +25,7 @@ function Script(URL, ApiKey, UseFolderName) {
     Logger.ILog(`Lookup Movie name: ${searchPattern}`);
 
     // Search for the movie in Radarr by path, queue, or download history
-    let movie = searchMovieByPath(searchPattern, radarr) ||
-                searchInQueue(searchPattern, radarr) ||
+    let movie = searchInQueue(searchPattern, radarr) ||
                 searchInDownloadHistory(searchPattern, radarr) ||
                 searchInGrabHistory(searchPattern, radarr) ||
                 parseMovieName(searchPattern, radarr);
@@ -69,6 +70,8 @@ function updateMovieMetadata(movie) {
         Genres: movie.genres
     };
 
+    Variables["Radarr.movieId"] = movie.id ?? null;
+    Logger.ILog(`Detected movieId: ${movie.id}`);
     Variables.MovieInfo = movie;
     Variables.OriginalLanguage = lang;
     Logger.ILog(`Detected Original Language: ${lang}`);
@@ -81,24 +84,6 @@ function updateMovieMetadata(movie) {
  */
 function getMovieFolderName(folderPath) {
     return System.IO.Path.GetFileName(folderPath);
-}
-
-/**
- * @description Searches for a movie by file or folder path in Radarr
- * @param {string} searchPattern - The search string to use (from the folder or file name)
- * @param {Object} radarr - Radarr API instance
- * @returns {Object|null} Movie object if found, or null if not found
- */
-function searchMovieByPath(searchPattern, radarr) {
-    Logger.ILog(`Searching by Movie path`);
-
-    try {
-        const movie = radarr.getMovieByPath(searchPattern);
-        return movie || null;
-    } catch (error) {
-        Logger.ELog(`Error searching movie by path: ${error.message}`);
-        return null;
-    }
 }
 
 /**
@@ -214,6 +199,7 @@ function searchRadarrAPI(endpoint, searchPattern, radarr, matchFunction, extraPa
             const matchingItem = items.find(item => matchFunction(item, sp));
             if (matchingItem) {
                 Logger.ILog(`Found Movie: ${matchingItem.movie.title}`);
+                
                 return matchingItem.movie;
             }
 

--- a/Scripts/Flow/Applications/Radarr/Radarr - Movie Lookup.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Movie Lookup.js
@@ -26,9 +26,9 @@ function Script(URL, ApiKey, UseFolderName) {
 
     // Search for the movie in Radarr by path, queue, or download history
     let movie = searchInQueue(searchPattern, radarr) ||
-                searchInDownloadHistory(searchPattern, radarr) ||
+                parseMovieName(searchPattern, radarr) ||
                 searchInGrabHistory(searchPattern, radarr) ||
-                parseMovieName(searchPattern, radarr);
+                searchInDownloadHistory(searchPattern, radarr);
 
     if (!movie) {
         Logger.ILog(`No result found for: ${searchPattern}`);

--- a/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
@@ -28,7 +28,7 @@ function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
 
     /*── movieId detection ──────────────────────────────────*/
     const searchPattern = Variables.file.Orig.FileNameNoExtension;
-    const movieId = Variables['Radarr.movieId'] ?? Variables.MovieInfo.id ?? parseMovie(searchPattern, radarr) ?? null;
+    let movieId = Variables['Radarr.movieId'] ?? Variables.MovieInfo.id ?? parseMovie(searchPattern, radarr) ?? null;
 
     Logger.ILog(`Radarr URL: ${URL}`);
     Logger.ILog(`Triggering Path: ${ImportPath}`);

--- a/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
@@ -3,9 +3,11 @@ import { Radarr } from 'Shared/Radarr';
 /**
  * @name Radarr - Trigger Manual Import
  * @uid 0e522a46-ed76-4b40-bd1f-b3baac64264c
- * @description Trigger Radarr to manually import the media, run after last file in folder moved.
+ * @description Trigger Radarr to manually import the media.
+ * @help Performs Radarr import to the Movie
+ * Run last after file move.
  * @author iBuSH
- * @revision 5
+ * @revision 6
  * @param {string} URL Radarr root URL and port (e.g. http://radarr:7878).
  * @param {string} ApiKey Radarr API Key.
  * @param {string} ImportPath The output path for import triggering (default Working File).
@@ -15,37 +17,199 @@ import { Radarr } from 'Shared/Radarr';
  * @output Command sent
  */
 function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
-  URL = URL || Variables['Radarr.Url'] || Variables['Radarr.URI'];
-  URL = URL.replace(/\/+$/g, "");
-  ApiKey = ApiKey || Variables['Radarr.ApiKey'];
-  ImportPath = ImportPath || Variables.file.FullName;
-  TimeOut = TimeOut ? Math.min(TimeOut, 600) * 1000 : 60000;
-  const ImportMode = MoveMode ? 'move' : 'copy';
-  const radarr = new Radarr(URL, ApiKey);
+    URL = (URL || Variables['Radarr.Url'] || Variables['Radarr.URI']).replace(/\/+$/g, '');
+    ApiKey = ApiKey || Variables['Radarr.ApiKey'];
+    ImportPath = ImportPath || Variables.file.FullName;
+    TimeOut = TimeOut ? Math.min(TimeOut, 600) * 1000 : 60000;  // ms
+    ImportPath = UseUnmappedPath ? Flow.UnMapPath(ImportPath) : ImportPath;
+    const importMode = MoveMode ? 'move' : 'copy';
 
-  if (UseUnmappedPath) ImportPath = Flow.UnMapPath(ImportPath);
+    const radarr = new Radarr(URL, ApiKey);
 
-  Logger.ILog(`Triggering URL: ${URL}`);
-  Logger.ILog(`Triggering Path: ${ImportPath}`);
-  Logger.ILog(`Import Mode: ${ImportMode}`);
+    /*── movieId detection ──────────────────────────────────*/
+    const movieId = Variables['Radarr.movieId'] ?? Variables.MovieInfo.id ?? null;
 
-  let commandBody = {
-      path: ImportPath,
-      importMode: ImportMode
+    Logger.ILog(`Radarr URL: ${URL}`);
+    Logger.ILog(`Triggering Path: ${ImportPath}`);
+    Logger.ILog(`Import Mode: ${importMode}`);
+    Logger.ILog(movieId ? `movieId: ${movieId} → ManualImport` : 'No movieId → downloadedMoviesScan');
+
+    /*─ Execute first workflow, then fail-over if needed ─*/
+    let result;
+    if (movieId) {
+        result = manualImportWorkflow(radarr, ImportPath, importMode, movieId, TimeOut);
+        if (result !== 1) {
+            Logger.WLog('ManualImport failed, falling back to downloadedMoviesScan.');
+            result = scanWorkflow(radarr, ImportPath, importMode, TimeOut);
+        }
+    } else {
+        result = scanWorkflow(radarr, ImportPath, importMode, TimeOut);
+    }
+
+    return result;
+
+}
+
+/*───────────────────────────── ManualImport ─────────────────────────────*/
+
+/**
+ * @description Perform ManualImport flow (when movieId is present) and wait until it finishes (or times out).
+ * @param {Radarr}  radarr - Radarr API instance
+ * @param {string}  importPath - Folder/File path given to movie import
+ * @param {string}  mode - 'move' or 'copy'
+ * @param {number}  movieId - Radarr movieId to attach to the import
+ * @param {number}  timeout - Timeout in milliseconds
+ * @returns {number} 1 on success, −1 on failure
+ */
+function manualImportWorkflow(radarr, importPath, mode, movieId, timeout) {
+    const candidates = getManualImportCandidates(radarr, importPath);
+    if (!candidates.length) {
+        Logger.WLog('No candidates returned by fetching ManualImport');
+        return -1;
+    }
+
+    /* choose the first candidate that has quality info */
+    const cand = candidates.find(c => c.quality && c.quality.quality);
+    if (!cand) {
+        Logger.WLog('No ManualImport candidate contained quality information.');
+        return -1;
+    }
+
+    const fileObj = buildManualImportFile(cand, movieId, importPath);
+    const cmdBody = { name: 'ManualImport', files: [fileObj], importMode: mode };
+    const cmdId = sendManualImportCommand(radarr, cmdBody);
+    if (cmdId === null) {
+        Logger.WLog('Failed sending ManualImport command');
+        return -1;
+    }
+
+    return waitForCommand(radarr, cmdId, timeout);
+}
+
+/**
+ * @description Retrieve candidate files from Radarr’s **Manual Import** analyser.
+ * @param {Radarr} radarr – Radarr API instance
+ * @param {string} importPath – Folder/File path to inspect
+ * @returns {Array<object>} Array of candidate objects (empty array on error)
+ */
+function getManualImportCandidates(radarr, importPath) {
+    try {
+        const query = buildQueryParams({ folder: importPath });
+        const resp  = radarr.fetchJson('manualimport', query) || [];
+        Logger.ILog(`ManualImport returned ${resp.length} candidate(s).`);
+        return resp;
+    } catch (e) {
+        Logger.ELog(`Fetch candidates from ManualImport failed: ${e.message}`);
+        return [];
+    }
+}
+
+/**
+ * @description Build the minimal file-object required by Radarr's ManualImport POST body.
+ * @param {object} src – Single candidate object returned by ManualImport
+ * @param {number} movieId – Radarr movieId to which the file is linked
+ * @returns {object} File descriptor for ManualImport
+ */
+function buildManualImportFile(src, movieId, importPath) {
+    const path =  src.path || importPath
+    const fallbackFolder = System.IO.Path.GetFileName(System.IO.Path.GetDirectoryName(path)) ?? Variables.folder.Name;
+    Logger.ILog(`fallbackFolder ${fallbackFolder}`);
+
+    return {
+        path: path,
+        folderName: src.folderName || src.name || fallbackFolder,
+        movieId: movieId,
+        releaseGroup: src.releaseGroup || 'Radarr',
+        quality: src.quality,
+        languages: src.languages || [ { id:0, name:'Unknown' } ],
+        indexerFlags: src.indexerFlags ?? 0
     };
+}
 
-  let response = radarr.sendCommand('downloadedMoviesScan', commandBody)
+/**
+ * @description Send the **ManualImport** command to Radarr and return command-id
+ * @param {Radarr} radarr – Radarr API instance
+ * @param {object} cmdBody – Complete payload for ManualImport command
+ * @returns {number|null} Command id on success, null on failure
+ */
+function sendManualImportCommand(radarr, cmdBody) {
+    try {
+        const resp = radarr.sendCommand('ManualImport', cmdBody);
+        const cmdId = resp?.id;
+        Logger.ILog(cmdId ? `ManualImport queued (cmdId=${cmdId}).` : 'ManualImport failed.');
+        return cmdId ?? null;
+    } catch (e) {
+        Logger.ELog(`Send command ManualImport failed: ${e.message}`);
+        return null;
+    }
+}
 
-  // Wait for the completion of the scan
-  let commandId = response['id']
-  let importCompleted = radarr.waitForCompletion(commandId, TimeOut);
-  if (!importCompleted) {
-      Logger.WLog('Import failed');
-      return -1;
-  }
+/*──────────────────────────── downloadedMoviesScan ────────────────────────────*/
 
-  Logger.DLog(`Command ID: ${commandId}`);
-  Logger.ILog('Import completed successfully');
-  return 1;
+/**
+ * @description Perform the downloadedMoviesScan flow (when movieId is absent).
+ * @param {Radarr}  radarr – Radarr API instance
+ * @param {string}  importPath – Folder/File path for downloadedMoviesScan
+ * @param {string}  mode – 'move' or 'copy'
+ * @param {number}  timeout – Timeout in milliseconds
+ * @returns {number} 1 on success, −1 on failure
+ */
+function scanWorkflow(radarr, importPath, mode, timeout) {
+    const cmdId = sendDownloadedMoviesScan(radarr, importPath, mode);
+    if (cmdId === null) {
+        Logger.WLog('Faild sending downloadedMoviesScan command');
+        return -1;
+    }
 
+    return waitForCommand(radarr, cmdId, timeout);
+}
+
+/**
+ * @description Send the **downloadedMoviesScan** command.
+ * @param {Radarr} radarr - Radarr API instance
+ * @param {string} importPath - Folder/File path for the scan
+ * @param {string} mode  - 'move' or 'copy'
+ * @returns {number|null} command id or null
+ */
+function sendDownloadedMoviesScan(radarr, importPath, mode) {
+    try {
+        const resp = radarr.sendCommand('downloadedMoviesScan', { path: importPath, importMode: mode });
+        const cmdId = resp?.id;
+        Logger.ILog(cmdId ? `downloadedMoviesScan queued (cmdId=${cmdId}).` : 'downloadedMoviesScan failed.');
+        return cmdId ?? null;
+    } catch (e) {
+        Logger.ELog(`Send command downloadedMoviesScan failed: ${e.message}`);
+        return null;
+    }
+}
+
+/*────────────────────────────── helpers ──────────────────────────────────*/
+
+/**
+ * @description Poll Radarr until the command id completes or timeout is reached.
+ * @param {Radarr} radarr - Radarr API instance
+ * @param {number}  cmdId - Command id returned by sendCommand
+ * @param {number}  timeoutMs - Maximum time to wait in milliseconds
+ * @returns {number} 1 on success, −1 on timeout
+ */
+function waitForCommand(radarr, cmdId, timeoutMs) {
+    const ok = radarr.waitForCompletion(cmdId, timeoutMs);
+    if (ok) {
+        Logger.DLog(`Command ${cmdId} completed.`);
+        Logger.ILog('Import completed successfully');
+        return 1;
+    }
+    Logger.WLog('Import timed out or failed.');
+    return -1;
+}
+
+/**
+ * @description Constructs a query string from the given parameters
+ * @param {Object} params - Key-value pairs to be converted into a query string
+ * @returns {string} The constructed query string
+ */
+function buildQueryParams(obj) {
+    return Object.entries(obj)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('&');
 }

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Trigger Manual Import.js
@@ -3,9 +3,11 @@ import { Sonarr } from 'Shared/Sonarr';
 /**
  * @name Sonarr - Trigger Manual Import
  * @uid 8fe63a47-4a97-4b08-99f4-368d29279ad2
- * @description Trigger Sonarr to manually import the media, run after last file in folder moved.
+ * @description Trigger Sonarr to manually import the media.
+ * @help Performs Sonarr import to the TV Show
+ * Run last after file move.
  * @author iBuSH
- * @revision 5
+ * @revision 6
  * @param {string} URL Sonarr root URL and port (e.g. http://sonarr:8989).
  * @param {string} ApiKey Sonarr API Key.
  * @param {string} ImportPath The output path for import triggering (default Working File).
@@ -15,38 +17,209 @@ import { Sonarr } from 'Shared/Sonarr';
  * @output Command sent
  */
 function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
-  URL = URL || Variables['Sonarr.Url'] || Variables['Sonarr.URI'];
-  URL = URL.replace(/\/+$/g, "");
-  ApiKey = ApiKey || Variables['Sonarr.ApiKey'];
-  ImportPath = ImportPath || Variables.file.FullName;
-  TimeOut = TimeOut ? Math.min(TimeOut, 600) * 1000 : 60000;
-  const ImportMode = MoveMode ? 'move' : 'copy';
-  const sonarr = new Sonarr(URL, ApiKey);
+    URL = (URL || Variables['Sonarr.Url'] || Variables['Sonarr.URI']).replace(/\/+$/g, '');
+    ApiKey = ApiKey || Variables['Sonarr.ApiKey'];
+    ImportPath = ImportPath || Variables.file.FullName;
+    TimeOut = TimeOut ? Math.min(TimeOut, 600) * 1000 : 60000;  // ms
+    ImportPath = UseUnmappedPath ? Flow.UnMapPath(ImportPath) : ImportPath;
+    const importMode = MoveMode ? 'move' : 'copy';
 
-  if (UseUnmappedPath) ImportPath = Flow.UnMapPath(ImportPath);
+    const sonarr = new Sonarr(URL, ApiKey);
 
-  Logger.ILog(`Triggering URL: ${URL}`);
-  Logger.ILog(`Triggering Path: ${ImportPath}`);
-  Logger.ILog(`Import Mode: ${ImportMode}`);
+    /*── seriesId / episodeId detection ──────────────────────────────────*/
+    const seriesId = Variables['Sonarr.seriesId'] ?? Variables.TVShowInfo?.id ?? null;
+    const episodeIds = Variables['Sonarr.episodeIds'] ?? Variables.TVShowInfo?.EpisodesInfo ?? null;
 
+    Logger.ILog(`Sonarr URL: ${URL}`);
+    Logger.ILog(`Triggering Path: ${ImportPath}`);
+    Logger.ILog(`Import Mode: ${importMode}`);
 
-  let commandBody = {
-      path: ImportPath,
-      importMode: ImportMode
+    if (seriesId && episodeIds)
+        Logger.ILog(`seriesId=${seriesId}, episodeIds=[${episodeIds.join(', ')}] → ManualImport`);
+    else
+        Logger.ILog('No seriesId/episodeIds → downloadedEpisodesScan');
+
+    /*─ Execute first workflow, then fail-over if needed ─*/
+    let result;
+    if (seriesId && episodeIds) {
+        result = manualImportWorkflow(sonarr, ImportPath, importMode, seriesId, episodeIds, TimeOut);
+        if (result !== 1) {
+            Logger.WLog('ManualImport failed, falling back to downloadedEpisodesScan.');
+            result = scanWorkflow(sonarr, ImportPath, importMode, TimeOut);
+        }
+    } else {
+        result = scanWorkflow(sonarr, ImportPath, importMode, TimeOut);
+    }
+
+    return result;
+}
+
+/*───────────────────────────── ManualImport ─────────────────────────────*/
+
+/**
+ * @description Perform ManualImport flow and wait until it finishes (or times out).
+ * @param {Sonarr}  sonarr - Sonarr API instance
+ * @param {string}  importPath - Folder/File path given to seires import
+ * @param {string}  mode - 'move' or 'copy'
+ * @param {number}  seriesId - Sonarr seriesId to attach to the import
+ * @param {number}  episodeIds - Sonarr episodeIds to attach to the import
+ * @param {number}  timeout - Timeout in milliseconds
+ * @returns {number} 1 on success, −1 on failure
+ */
+function manualImportWorkflow(sonarr, path, mode, seriesId, episodeIds, timeout) {
+    const candidates = getManualImportCandidates(sonarr, path);
+    if (!candidates.length) {
+        Logger.WLog('No candidates returned by fetching ManualImport');
+        return -1;
+    }
+
+    /* choose the first candidate that has quality info */
+    const cand = candidates.find(c => c.quality && c.quality.quality);
+    if (!cand) {
+        Logger.WLog('No ManualImport candidate contained quality information.');
+        return -1;
+    }
+
+    const fileObj = buildManualImportFile(cand, seriesId, episodeIds, path);
+    const cmdBody = { name: 'ManualImport', files: [fileObj], importMode: mode };
+    const cmdId   = sendManualImportCommand(sonarr, cmdBody);
+    if (cmdId === null) {
+        Logger.WLog('Failed sending ManualImport command');
+        return -1;
+    }
+
+    return waitForCommand(sonarr, cmdId, timeout);
+}
+
+/**
+ * @description Retrieve candidate files from Sonarr’s **Manual Import** analyser.
+ * @param {Sonarr} sonarr - Sonarr API instance
+ * @param {string} importPath - Folder/File path to inspect
+ * @returns {Array<object>} Array of candidate objects (empty array on error)
+ */
+function getManualImportCandidates(sonarr, importPath) {
+    try {
+        const query = buildQueryParams({ folder: importPath });
+        const resp  = sonarr.fetchJson('manualimport', query) || [];
+        Logger.ILog(`ManualImport returned ${resp.length} candidate(s).`);
+        return resp;
+    } catch (e) {
+        Logger.ELog(`Fetch candidates from ManualImport failed: ${e.message}`);
+        return [];
+    }
+}
+
+/**
+ * Build a fully-populated file object for Sonarr ManualImport.
+ */
+/**
+ * @description Build the minimal file-object required by Sonarr's ManualImport POST body.
+ * @param {object} src – Single candidate object returned by ManualImport
+ * @param {number} seriesId – Sonarr seriesId to which the file is linked
+ * @param {number} episodeIds – Sonarr episodeIds to which the file is linked
+ * @returns {object} File descriptor for ManualImport
+ */
+function buildManualImportFile(src, seriesId, episodeIds, importPath) {
+    const path = src.path || importPath;
+    const fallbackFolder = System.IO.Path.GetFileName(System.IO.Path.GetDirectoryName(path)) ?? Variables.folder.Name;
+
+    return {
+        path: path,
+        folderName: src.folderName || src.name || fallbackFolder,
+        seriesId: seriesId,
+        episodeIds: episodeIds,
+        releaseGroup: src.releaseGroup || 'Sonarr',
+        quality: src.quality,
+        languages: src.languages || [ { id:0, name:'Unknown' } ],
+        indexerFlags: src.indexerFlags ?? 0,
+        releaseType: src.releaseType ?? 'unknown'
     };
+}
 
-  let response = sonarr.sendCommand('downloadedEpisodesScan', commandBody)
+/**
+ * @description Send the **ManualImport** command to Sonarr and return command-id
+ * @param {Sonarr} sonarr – Sonarr API instance
+ * @param {object} cmdBody – Complete payload for ManualImport command
+ * @returns {number|null} Command id on success, null on failure
+ */
+function sendManualImportCommand(sonarr, cmdBody) {
+    try {
+        const resp = sonarr.sendCommand('ManualImport', cmdBody);
+        const cmdId   = resp?.id;
+        Logger.ILog(cmdId ? `ManualImport queued (cmdId=${cmdId}).` : 'ManualImport failed.');
+        return cmdId ?? null;
+    } catch (e) {
+        Logger.ELog(`Send command ManualImport failed: ${e.message}`);
+        return null;
+    }
+}
 
-  // Wait for the completion of the scan
-  let commandId = response['id']
-  let importCompleted = sonarr.waitForCompletion(commandId, TimeOut);
-  if (!importCompleted) {
-      Logger.WLog('Import failed');
-      return -1;
-  }
+/*──────────────────────── downloadedEpisodesScan branch ─────────────────────*/
 
-  Logger.DLog(`Command ID: ${commandId}`);
-  Logger.ILog('Import completed successfully');
-  return 1;
+/**
+ * @description Perform the downloadedEpisodesScan flow (when seriesId is absent).
+ * @param {Sonarr}  sonarr – Sonarr API instance
+ * @param {string}  importPath – Folder/File path for downloadedEpisodesScan
+ * @param {string}  mode – 'move' or 'copy'
+ * @param {number}  timeout – Timeout in milliseconds
+ * @returns {number} 1 on success, −1 on failure
+ */
+function scanWorkflow(sonarr, importPath, mode, timeout) {
+    const cmdId = sendDownloadedEpisodesScan(sonarr, importPath, mode);
+    if (cmdId === null) {
+        Logger.WLog('Faild sending downloadedEpisodesScan command');
+        return -1;
+    }
 
+    return waitForCommand(sonarr, cmdId, timeout);
+}
+
+/**
+ * @description Send the **downloadedEpisodesScan** command.
+ * @param {Sonarr} sonarr - Sonarr API instance
+ * @param {string} importPath - Folder/File path for the scan
+ * @param {string} mode  - 'move' or 'copy'
+ * @returns {number|null} command id or null
+ */
+function sendDownloadedEpisodesScan(sonarr, importPath, mode) {
+    try {
+        const resp = sonarr.sendCommand('downloadedEpisodesScan', { path: importPath, importMode: mode });
+        const cmdId   = resp?.id;
+        Logger.ILog(cmdId ? `downloadedEpisodesScan queued (cmdId=${cmdId}).` : 'downloadedEpisodesScan failed.');
+        return cmdId ?? null;
+    } catch (e) {
+        Logger.ELog(`Send command downloadedEpisodesScan failed: ${e.message}`);
+        return null;
+    }
+}
+
+/*────────────────────────────── helpers ──────────────────────────────────*/
+
+/**
+ * @description Poll Sonarr until the command id completes or timeout is reached.
+ * @param {Sonarr} sonarr - Sonarr API instance
+ * @param {number}  cmdId - Command id returned by sendCommand
+ * @param {number}  timeoutMs - Maximum time to wait in milliseconds
+ * @returns {number} 1 on success, −1 on timeout
+ */
+function waitForCommand(sonarr, cmdId, timeoutMs) {
+    const ok = sonarr.waitForCompletion(cmdId, timeoutMs);
+    if (ok) {
+        Logger.DLog(`Command ${cmdId} completed.`);
+        Logger.ILog('Import completed successfully');
+        return 1;
+    }
+    Logger.WLog('Import timed out or failed.');
+    return -1;
+}
+
+/**
+ * @description Constructs a query string from the given parameters
+ * @param {Object} params - Key-value pairs to be converted into a query string
+ * @returns {string} The constructed query string
+ */
+function buildQueryParams(obj) {
+    return Object.entries(obj)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('&');
 }

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Trigger Manual Import.js
@@ -28,18 +28,18 @@ function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
 
     /*── seriesId / episodeId detection ──────────────────────────────────*/
     const searchPattern = Variables.file.Orig.FileNameNoExtension;
-    const seriesId = Variables['Sonarr.seriesId'] ?? Variables.TVShowInfo?.id ?? null;
-    const episodeIds = Variables['Sonarr.episodeIds'] ?? Variables.TVShowInfo?.EpisodesInfo ?? null;
+    let seriesId = Variables['Sonarr.seriesId'] ?? Variables.TVShowInfo?.id ?? null;
+    let episodeIds = Variables['Sonarr.episodeIds'] ?? Variables.TVShowInfo?.EpisodesInfo ?? null;
 
     Logger.ILog(`Sonarr URL: ${URL}`);
     Logger.ILog(`Triggering Path: ${ImportPath}`);
     Logger.ILog(`Import Mode: ${importMode}`);
 
-    if (seriesId && episodeIds)
+    if (seriesId && episodeIds) {
         Logger.ILog(`seriesId=${seriesId}, episodeIds=[${episodeIds.join(', ')}] → ManualImport`);
-    else
+    } else {
         Logger.ILog('No seriesId/episodeIds, Trying parsing from File/Folder name');
-        let parsedSeries = parseSeries(searchPattern, sonarr)
+        const parsedSeries = parseSeries(searchPattern, sonarr)
         seriesId = parsedSeries?.id ?? null
         episodeIds = parsedSeries?.episodeIds ?? null
         Logger.ILog(
@@ -47,7 +47,8 @@ function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
                 ? `seriesId=${seriesId}, episodeIds=[${episodeIds.join(', ')}] → ManualImport`
                 : 'No seriesId/episodeIds → downloadedEpisodesScan'
         );
-
+    }
+        
 
     /*─ Execute first workflow, then fail-over if needed ─*/
     let result;

--- a/Scripts/Flow/Applications/Sonarr/Sonarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Sonarr/Sonarr - Trigger Manual Import.js
@@ -28,8 +28,8 @@ function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
 
     /*── seriesId / episodeId detection ──────────────────────────────────*/
     const searchPattern = Variables.file.Orig.FileNameNoExtension;
-    const seriesId = Variables['Sonarr.seriesId'] ?? Variables.TVShowInfo?.id ?? parseSeries(searchPattern, sonarr).id ?? null;
-    const episodeIds = Variables['Sonarr.episodeIds'] ?? Variables.TVShowInfo?.EpisodesInfo ?? parseSeries(searchPattern, sonarr).episodeIds ?? null;
+    const seriesId = Variables['Sonarr.seriesId'] ?? Variables.TVShowInfo?.id ?? null;
+    const episodeIds = Variables['Sonarr.episodeIds'] ?? Variables.TVShowInfo?.EpisodesInfo ?? null;
 
     Logger.ILog(`Sonarr URL: ${URL}`);
     Logger.ILog(`Triggering Path: ${ImportPath}`);
@@ -38,7 +38,16 @@ function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
     if (seriesId && episodeIds)
         Logger.ILog(`seriesId=${seriesId}, episodeIds=[${episodeIds.join(', ')}] → ManualImport`);
     else
-        Logger.ILog('No seriesId/episodeIds → downloadedEpisodesScan');
+        Logger.ILog('No seriesId/episodeIds, Trying parsing from File/Folder name');
+        let parsedSeries = parseSeries(searchPattern, sonarr)
+        seriesId = parsedSeries?.id ?? null
+        episodeIds = parsedSeries?.episodeIds ?? null
+        Logger.ILog(
+            seriesId && episodeIds
+                ? `seriesId=${seriesId}, episodeIds=[${episodeIds.join(', ')}] → ManualImport`
+                : 'No seriesId/episodeIds → downloadedEpisodesScan'
+        );
+
 
     /*─ Execute first workflow, then fail-over if needed ─*/
     let result;


### PR DESCRIPTION
Big improvement for Sonarr/Radarr Import media, using 2 flows when that will use `Manual Import` as in UI or `Download Scan` command.
To work with Manual Import, the users will need to add Radarr/Sonarr lookup scripts or it will use the `Download Scan` by default.

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
